### PR TITLE
Don't require queue flags on dual or cache subcommands

### DIFF
--- a/mettle/BUILD
+++ b/mettle/BUILD
@@ -12,6 +12,6 @@ go_binary(
 
 sh_cmd(
     name = "run_local",
-    cmd = "exec $(out_location :mettle) dual -s 127.0.0.1:7777 -q mem://requests -r mem://responses -d plz-out/mettle -v 4 --log_file plz-out/log/mettle.log --browser http://127.0.0.1:7779 --sandbox ~/.please/please_sandbox",
+    cmd = "exec $(out_location :mettle) dual -s 127.0.0.1:7777 -d plz-out/mettle -v 4 --log_file plz-out/log/mettle.log --browser http://127.0.0.1:7779 --sandbox ~/.please/please_sandbox",
     srcs = [":mettle"],
 )


### PR DESCRIPTION
Cache never uses it, and it is basically pointless in dual mode (if you're not using in-memory queues you could use the normal commands anyway) so we hard code it to in-memory there.