### PR TITLE
Add check for empty hashes in flair's FindMissingBlobs rpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Please output directory
 plz-out
 .plzconfig.local
+.idea

--- a/flair/rpc/rpc.go
+++ b/flair/rpc/rpc.go
@@ -112,8 +112,11 @@ func (s *server) FindMissingBlobs(ctx context.Context, req *pb.FindMissingBlobsR
 	// blocks are of a consistent size). This currently fits our setup.
 	blobs := map[*trie.Server][]*pb.Digest{}
 	for _, d := range req.BlobDigests {
-		s := s.replicator.Trie.Get(d.Hash)
-		blobs[s] = append(blobs[s], d)
+		// Empty directories have empty hashes. We don't need to check for them.
+		if d.Hash != "" {
+			s := s.replicator.Trie.Get(d.Hash)
+			blobs[s] = append(blobs[s], d)
+		}
 	}
 	resp := &pb.FindMissingBlobsResponse{}
 	var g errgroup.Group


### PR DESCRIPTION
The action result that please was getting back from mettle contained empty directories that have a digest with an empty hash. Please was validating the action result and checking for missing blobs. When flair was trying to figure out which worker would have this blob, it was getting an index out of bounds parsing this hash. This just skips over empty hashes in the FindEmptyBlobs rpc. 