### PR TITLE
Binary commands: iterate over the outputs paths rather than files and directories

### DIFF
--- a/discern/main.go
+++ b/discern/main.go
@@ -25,7 +25,7 @@ var opts = struct {
 	Usage     string
 	Verbosity cli.Verbosity `short:"v" long:"verbosity" default:"notice" description:"Verbosity of output (higher number = more output)"`
 	Storage   struct {
-		InstanceName string `long:"instance" default:"mettle" description:"Instance name"`
+		InstanceName string `short:"i" long:"instance" default:"mettle" description:"Instance name"`
 		Storage      string `short:"s" long:"storage" required:"true" description:"URL to connect to the CAS server on, e.g. localhost:7878"`
 		TLS          bool   `long:"tls" description:"Use TLS for communication with the storage server"`
 	} `group:"Options controlling connection to the CAS server"`

--- a/mettle/worker/worker.go
+++ b/mettle/worker/worker.go
@@ -682,12 +682,9 @@ func (w *worker) markOutputsAsBinary(cmd *pb.Command) error {
 // collectOutputs collects all the outputs of a command and adds them to the given ActionResult.
 func (w *worker) collectOutputs(ar *pb.ActionResult, cmd *pb.Command) error {
 	if containsEnvVar(cmd, "_BINARY", "true") {
-		log.Warningf("output is binary ")
 		if err := w.markOutputsAsBinary(cmd); err != nil {
 			return err
 		}
-	} else {
-		log.Warningf("output is not binary ")
 	}
 
 	m, ar2, err := tree.ComputeOutputsToUpload(w.dir, cmd.OutputPaths, int(w.client.ChunkMaxSize), filemetadata.NewNoopCache())


### PR DESCRIPTION
Turns out we don't really know if outputs are a file or directory so we need to check. 