### PR TITLE
Attempt to upload action outputs files even if the action failed

### DIFF
--- a/mettle/worker/worker.go
+++ b/mettle/worker/worker.go
@@ -505,6 +505,8 @@ func (w *worker) execute(action *pb.Action, command *pb.Command) *pb.ExecuteResp
 	if err != nil {
 		msg := "Execution failed: " + err.Error()
 		msg += w.writeUncachedResult(ar, msg)
+		// Attempt to collect outputs. They may exist and contain useful information such as a test.results file
+		_ = w.collectOutputs(ar, command)
 		return &pb.ExecuteResponse{
 			Status:  &rpcstatus.Status{Code: int32(codes.OK)}, // Still counts as OK on a status code.
 			Result:  ar,


### PR DESCRIPTION
There may be some useful information in there that the client can use to diagnose what went wrong i.e. the test.results XML