### PR TITLE
Better timeout resilience

### DIFF
--- a/flair/main.go
+++ b/flair/main.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/peterebden/go-cli-init"
 	"github.com/thought-machine/http-admin"
 	"google.golang.org/grpc"
@@ -26,6 +28,7 @@ var opts = struct {
 	ExecutorGeometry map[string]string `short:"e" long:"executor_geometry" description:"Executor server geometry to forward request to. If not given then the executor API will be unavailable."`
 	Replicas         int               `short:"r" long:"replicas" default:"1" description:"Number of servers to replicate reads/writes to"`
 	ConnTLS          bool              `long:"tls" description:"Use TLS for connecting to other servers"`
+	Timeout          cli.Duration      `long:"timeout" default:"10s" description:"Default timeout for all RPCs"`
 	CA               string            `long:"ca" description:"File containing PEM-formatted CA certificate to verify TLS connections with"`
 	Admin            admin.Opts        `group:"Options controlling HTTP admin server" namespace:"admin"`
 }{
@@ -53,7 +56,7 @@ func main() {
 	cr := newReplicator(opts.Geometry, opts.Replicas)
 	ar := newReplicator(opts.AssetGeometry, opts.Replicas)
 	er := newReplicator(opts.ExecutorGeometry, opts.Replicas)
-	rpc.ServeForever(opts.GRPC, cr, ar, er)
+	rpc.ServeForever(opts.GRPC, cr, ar, er, time.Duration(opts.Timeout))
 }
 
 func newReplicator(geometry map[string]string, replicas int) *trie.Replicator {

--- a/flair/main.go
+++ b/flair/main.go
@@ -28,7 +28,7 @@ var opts = struct {
 	ExecutorGeometry map[string]string `short:"e" long:"executor_geometry" description:"Executor server geometry to forward request to. If not given then the executor API will be unavailable."`
 	Replicas         int               `short:"r" long:"replicas" default:"1" description:"Number of servers to replicate reads/writes to"`
 	ConnTLS          bool              `long:"tls" description:"Use TLS for connecting to other servers"`
-	Timeout          cli.Duration      `long:"timeout" default:"10s" description:"Default timeout for all RPCs"`
+	Timeout          cli.Duration      `long:"timeout" default:"20s" description:"Default timeout for all RPCs"`
 	CA               string            `long:"ca" description:"File containing PEM-formatted CA certificate to verify TLS connections with"`
 	Admin            admin.Opts        `group:"Options controlling HTTP admin server" namespace:"admin"`
 }{

--- a/flair/trie/replication.go
+++ b/flair/trie/replication.go
@@ -195,7 +195,7 @@ func (r *Replicator) recheckOnce(s *Server) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if _, err := s.Health.Check(ctx, &grpc_health_v1.HealthCheckRequest{}); err != nil {
-		log.Debug("Server %s-%s is still unhealthy", s.Start, s.End)
+		log.Warning("Server %s-%s is still unhealthy: %s", s.Start, s.End, err)
 		return false
 	}
 	log.Notice("Server %s-%s is now healthy again", s.Start, s.End)

--- a/flair/trie/replication.go
+++ b/flair/trie/replication.go
@@ -20,10 +20,10 @@ var serverDead = status.Errorf(codes.DeadlineExceeded, "Server is down")
 
 // failureThreshold is the number of timeouts we tolerate on a server before marking it
 // out of service.
-const failureThreshold = 3
+const failureThreshold = 5
 
 // recheckFrequency is the rate at which we re-check dead servers to see if they become alive again.
-const recheckFrequency = 2 * time.Minute
+const recheckFrequency = 1 * time.Minute
 
 // A Replicator implements replication for our RPCs.
 type Replicator struct {

--- a/flair/trie/replication.go
+++ b/flair/trie/replication.go
@@ -70,7 +70,7 @@ func (r *Replicator) SequentialAck(key string, f ReplicatedAckFunc) error {
 	offset := 0
 	for i := 0; i < r.Replicas; i++ {
 		shouldContinue, err := r.callAck(f, r.Trie.GetOffset(key, offset))
-		if !r.shouldRetry(err) && !shouldContinue {
+		if !r.isContinuable(err) && !shouldContinue {
 			return err
 		}
 		if e == nil || (err != nil && e == serverDead) {
@@ -203,8 +203,8 @@ func (r *Replicator) recheckOnce(s *Server) bool {
 	return true
 }
 
-// shouldRetry returns true if the given error is retryable.
-func (r *Replicator) shouldRetry(err error) bool {
+// isContinuable returns true if the given error is retryable.
+func (r *Replicator) isContinuable(err error) bool {
 	switch status.Code(err) {
 	case codes.Unknown:
 		return true // Unclear, might as well try again

--- a/flair/trie/replication.go
+++ b/flair/trie/replication.go
@@ -1,16 +1,29 @@
 package trie
 
 import (
+	"context"
 	"fmt"
+	"sync/atomic"
+	"time"
 
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/hashicorp/go-multierror"
 	"github.com/peterebden/go-cli-init"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 )
 
 var log = cli.MustGetLogger()
+
+var serverDead = status.Errorf(codes.DeadlineExceeded, "Server is down")
+
+// failureThreshold is the number of timeouts we tolerate on a server before marking it
+// out of service.
+const failureThreshold = 3
+
+// recheckFrequency is the rate at which we re-check dead servers to see if they become alive again.
+const recheckFrequency = 2 * time.Minute
 
 // A Replicator implements replication for our RPCs.
 type Replicator struct {
@@ -55,19 +68,20 @@ func (r *Replicator) SequentialAck(key string, f ReplicatedAckFunc) error {
 	var e error
 	offset := 0
 	for i := 0; i < r.Replicas; i++ {
-		shouldContinue, err := f(r.Trie.GetOffset(key, offset))
+		shouldContinue, err := r.callAck(f, r.Trie.GetOffset(key, offset))
 		if !r.shouldRetry(err) && !shouldContinue {
 			return err
+		}
+		if e == nil {
+			e = err
 		}
 		if err == nil {
 			log.Debug("Caller requested to continue on next replica for %s", key)
 		} else if i < r.Replicas-1 {
 			log.Debug("Error reading from replica for %s: %s. Will retry on next replica.", key, err)
+			e = nil
 		} else {
 			log.Debug("Error reading from replica for %s: %s.", key, err)
-		}
-		if e == nil {
-			e = err
 		}
 		offset += r.increment
 	}
@@ -95,7 +109,7 @@ func (r *Replicator) Parallel(key string, f ReplicatedFunc) error {
 	for i := 0; i < r.Replicas; i++ {
 		o := offset
 		g.Go(func() error {
-			return f(r.Trie.GetOffset(key, o))
+			return r.call(f, r.Trie.GetOffset(key, o))
 		})
 		offset += r.increment
 	}
@@ -133,6 +147,57 @@ func (r *Replicator) All(key string, f ReplicatedFunc) error {
 		offset += r.increment
 	}
 	return g.Wait().ErrorOrNil()
+}
+
+// callAck calls a replicated function on a single replica, handling liveness on the server.
+func (r *Replicator) callAck(f ReplicatedAckFunc, s *Server) (bool, error) {
+	if s.Failed >= failureThreshold {
+		log.Debug("Skipping replica %s-%s, it is marked down", s.Start, s.End)
+		return true, serverDead
+	}
+	shouldContinue, err := f(s)
+	if status.Code(err) == codes.DeadlineExceeded {
+		if failed := atomic.AddInt64(&s.Failed, 1); failed == failureThreshold {
+			log.Error("Deadline exceeded on server %s-%s, taking it out of service", s.Start, s.End)
+			go r.recheck(s)
+		} else {
+			log.Warning("Deadline exceeded on server %s-%s, failures: %d", s.Start, s.End, failed)
+		}
+	} else if err == nil {
+		s.Failed = 0 // Must be OK since it responded to this RPC successfully
+	}
+	return shouldContinue, err
+}
+
+// call is like callAck but doesn't offer the option of acknowledgement.
+func (r *Replicator) call(f ReplicatedFunc, s *Server) error {
+	_, err := r.callAck(func(s *Server) (bool, error) {
+		return false, f(s)
+	}, s)
+	return err
+}
+
+// recheck continually rechecks a server to see if it's become alive again.
+func (r *Replicator) recheck(s *Server) {
+	t := time.NewTicker(recheckFrequency)
+	defer t.Stop()
+	for range t.C {
+		if r.recheckOnce(s) {
+			break
+		}
+	}
+}
+
+func (r *Replicator) recheckOnce(s *Server) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := s.Health.Check(ctx, &grpc_health_v1.HealthCheckRequest{}); err != nil {
+		log.Debug("Server %s-%s is still unhealthy", s.Start, s.End)
+		return false
+	}
+	log.Notice("Server %s-%s is now healthy again", s.Start, s.End)
+	s.Failed = 0
+	return true
 }
 
 // shouldRetry returns true if the given error is retryable.

--- a/grpcutil/interceptors.go
+++ b/grpcutil/interceptors.go
@@ -12,6 +12,8 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
@@ -54,6 +56,7 @@ func NewServer(opts Opts) (net.Listener, *grpc.Server) {
 	)...)
 	grpc_prometheus.Register(s)
 	reflection.Register(s)
+	grpc_health_v1.RegisterHealthServer(s, health.NewServer())
 	return lis, s
 }
 


### PR DESCRIPTION
Basically put timeouts on the individual RPCs plus a rolling timeout on streaming RPCs between each message.

Also adds a concept of server liveness whereby 'dead' servers can be taken out of the pool so we don't have to keep timing them out.