### PR TITLE
GC shouldn't extend lifetime of actions

### DIFF
--- a/elan/rpc/rpc.go
+++ b/elan/rpc/rpc.go
@@ -36,6 +36,7 @@ import (
 	bs "google.golang.org/genproto/googleapis/bytestream"
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/thought-machine/please-servers/grpcutil"
@@ -156,6 +157,10 @@ func (s *server) GetActionResult(ctx context.Context, req *pb.GetActionResultReq
 		}
 	}
 	if s.isFileStorage {
+		// If the caller indicated this was a GC action then don't extend the life of the result.
+		if md, ok := metadata.FromIncomingContext(ctx); ok && len(md.Get(grpcutil.GCKey)) > 0 {
+			return ar, nil
+		}
 		now := time.Now()
 		if err := os.Chtimes(path.Join(s.storageRoot, s.key("ac", req.ActionDigest)), now, now); err != nil {
 			log.Warning("Failed to change times on file: %s", err)

--- a/grpcutil/dial.go
+++ b/grpcutil/dial.go
@@ -120,3 +120,7 @@ func ShouldCompress(ctx context.Context) bool {
 func SkipCompression(ctx context.Context) context.Context {
 	return metadata.AppendToOutgoingContext(ctx, skipCompressionKey, "true")
 }
+
+// GCKey is a metadata key that we use to identify GC requests which don't extend the
+// lifetime of an action result.
+const GCKey = "purity-gc"

--- a/purity/gc/gc.go
+++ b/purity/gc/gc.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/peterebden/go-cli-init"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/thought-machine/please-servers/grpcutil"
 	ppb "github.com/thought-machine/please-servers/proto/purity"
@@ -206,6 +207,7 @@ func (c *collector) MarkReferencedBlobs() error {
 func (c *collector) markReferencedBlobs(ar *ppb.ActionResult) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
+	ctx = metadata.AppendToOutgoingContext(ctx, grpcutil.GCKey, "true")
 	dg := &pb.Digest{Hash: ar.Hash, SizeBytes: ar.SizeBytes}
 	result, err := c.client.GetActionResult(ctx, &pb.GetActionResultRequest{
 		InstanceName: c.client.InstanceName,


### PR DESCRIPTION
Currently the TTLs of actions get refreshed on each GC run. This obviously isn't right and leads to them living forever if you run it more frequently than its max age.