### PR TITLE
Nicer cli hashes

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -1,0 +1,18 @@
+go_library(
+    name = "cli",
+    srcs = ["cli.go"],
+    deps = [
+        "//third_party/go:cli-init",
+        "//third_party/go:remote-apis",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+go_test(
+    name = "cli_test",
+    srcs = ["cli_test.go"],
+    deps = [
+        ":cli",
+        "//third_party/go:testify",
+    ],
+)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -15,7 +15,7 @@ var log = cli.MustGetLogger()
 var actionRe = regexp.MustCompile("([0-9a-fA-F]+)/([0-9]+)/?")
 var shortActionRe = regexp.MustCompile("([0-9a-fA-F]+)")
 
-// A Action represents a combined hash / size pair written like
+// An Action represents a combined hash / size pair written like
 // ff17a4efe382e245491d6a9f1ac6bf3adce454f7e4a5559a3579c3856edf1381/122
 // This is a bit more concise than passing them with flags.
 type Action struct {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
-	"github.com/peterebden/go-cli-init"
+	"github.com/peterebden/go-cli-init/v2"
 )
 
 var log = cli.MustGetLogger()

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -58,3 +58,12 @@ func (a *Action) ToProto() *pb.Digest {
 		SizeBytes: int64(a.Size),
 	}
 }
+
+// AllToProto converts a slice of actions to protos.
+func AllToProto(actions []Action) []*pb.Digest {
+	ret := make([]*pb.Digest, len(actions))
+	for i, a := range actions {
+		ret[i] = a.ToProto()
+	}
+	return ret
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,60 @@
+// Package cli implements some simple shared CLI flag types.
+package cli
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	"github.com/peterebden/go-cli-init"
+)
+
+var log = cli.MustGetLogger()
+
+var actionRe = regexp.MustCompile("([0-9a-fA-F]+)/([0-9]+)/?")
+var shortActionRe = regexp.MustCompile("([0-9a-fA-F]+)")
+
+// A Action represents a combined hash / size pair written like
+// ff17a4efe382e245491d6a9f1ac6bf3adce454f7e4a5559a3579c3856edf1381/122
+// This is a bit more concise than passing them with flags.
+type Action struct {
+	Hash string
+	Size int
+}
+
+func (a *Action) UnmarshalFlag(in string) error {
+	matches := actionRe.FindStringSubmatch(in)
+	if matches != nil {
+		return a.fromComponents(matches[1], matches[2])
+	}
+	matches = shortActionRe.FindStringSubmatch(in)
+	if matches != nil {
+		return a.fromComponents(matches[1], "")
+	}
+	return fmt.Errorf("Unknown action format: %s", in)
+}
+
+func (a *Action) fromComponents(hash, size string) error {
+	if len(hash) != 64 {
+		return fmt.Errorf("Invalid hash %s; has length %d, should be 64", hash, len(hash))
+	}
+	a.Hash = hash
+	if size == "" {
+		// This looks a bit arbitrary but for whatever reason most of our actions (which is
+		// generally what you pass in here) are 147 bytes long.
+		log.Warning("Missing size in hash; arbitrarily guessing 147...")
+		a.Size = 147
+	} else {
+		a.Size, _ = strconv.Atoi(size)
+	}
+	return nil
+}
+
+// ToProto converts this Action to the proto digest.
+func (a *Action) ToProto() *pb.Digest {
+	return &pb.Digest{
+		Hash:      a.Hash,
+		SizeBytes: int64(a.Size),
+	}
+}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseProper(t *testing.T) {
+	var a Action
+	err := a.UnmarshalFlag("ff17a4efe382e245491d6a9f1ac6bf3adce454f7e4a5559a3579c3856edf1381/122")
+	assert.NoError(t, err)
+	assert.Equal(t, "ff17a4efe382e245491d6a9f1ac6bf3adce454f7e4a5559a3579c3856edf1381", a.Hash)
+	assert.Equal(t, 122, a.Size)
+}
+
+func TestParseTrailingSlash(t *testing.T) {
+	var a Action
+	err := a.UnmarshalFlag("ff17a4efe382e245491d6a9f1ac6bf3adce454f7e4a5559a3579c3856edf1381/122/")
+	assert.NoError(t, err)
+	assert.Equal(t, "ff17a4efe382e245491d6a9f1ac6bf3adce454f7e4a5559a3579c3856edf1381", a.Hash)
+	assert.Equal(t, 122, a.Size)
+}
+
+func TestParseShort(t *testing.T) {
+	var a Action
+	err := a.UnmarshalFlag("ff17a4efe382e245491d6a9f1ac6bf3adce454f7e4a5559a3579c3856edf1381")
+	assert.NoError(t, err)
+	assert.Equal(t, "ff17a4efe382e245491d6a9f1ac6bf3adce454f7e4a5559a3579c3856edf1381", a.Hash)
+	assert.Equal(t, 147, a.Size)
+}
+
+func TestParseFail(t *testing.T) {
+	var a Action
+	err := a.UnmarshalFlag("thirty-five ham and cheese sandwiches")
+	assert.Error(t, err)
+}
+
+func TestParseWrongLength(t *testing.T) {
+	var a Action
+	err := a.UnmarshalFlag("ff17a4efe382e245491d6a9f1ac6bf3adce454f7e4a5559a3579c3856edf138")
+	assert.Error(t, err)
+}

--- a/discern/BUILD
+++ b/discern/BUILD
@@ -2,6 +2,7 @@ go_binary(
     name = "discern",
     srcs = ["main.go"],
     deps = [
+        "//cli",
         "//grpcutil",
         "//purity/gc",
         "//third_party/go:cli-init",

--- a/mettle/BUILD
+++ b/mettle/BUILD
@@ -2,6 +2,7 @@ go_binary(
     name = "mettle",
     srcs = ["main.go"],
     deps = [
+        "//cli",
         "//grpcutil",
         "//mettle/worker",
         "//mettle/api",

--- a/purity/BUILD
+++ b/purity/BUILD
@@ -2,6 +2,7 @@ go_binary(
     name = "purity",
     srcs = ["main.go"],
     deps = [
+        "//cli",
         "//purity/gc",
         "//grpcutil",
         "//third_party/go:cli-init",

--- a/purity/main.go
+++ b/purity/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/peterebden/go-cli-init/v2"
 	admin "github.com/thought-machine/http-admin"
 
+	flags "github.com/thought-machine/please-servers/cli"
 	"github.com/thought-machine/please-servers/purity/gc"
 )
 
@@ -35,7 +36,7 @@ var opts = struct {
 	} `command:"periodic" description:"Run continually, triggering GCs at a regular interval"`
 	Delete struct {
 		Args struct {
-			Hashes []string `positional-arg-name:"hashes" required:"true" description:"Hashes to delete"`
+			Actions []flags.Action `positional-arg-name:"actions" required:"true" description:"Actions to delete"`
 		} `positional-args:"true" required:"true"`
 	} `command:"delete" description:"Deletes one or more build actions from the server."`
 	Clean struct {
@@ -68,7 +69,7 @@ func main() {
 		go admin.Serve(opts.Admin)
 		gc.RunForever(opts.GC.URL, opts.GC.InstanceName, opts.GC.TokenFile, opts.GC.TLS, time.Duration(opts.Periodic.MinAge), time.Duration(opts.Periodic.Frequency))
 	} else if cmd == "delete" {
-		if err := gc.Delete(opts.GC.URL, opts.GC.InstanceName, opts.GC.TokenFile, opts.GC.TLS, opts.Delete.Args.Hashes); err != nil {
+		if err := gc.Delete(opts.GC.URL, opts.GC.InstanceName, opts.GC.TokenFile, opts.GC.TLS, flags.AllToProto(opts.Delete.Args.Actions)); err != nil {
 			log.Fatalf("Failed to delete: %s", err)
 		}
 	} else if cmd == "clean" {


### PR DESCRIPTION
Rather than passing as `--hash` and `--size`, parse them like URL fragments from the browser (which is what I often have if I'm pasting in, and is intuitive enough otherwise).

For example:
```
plz run //discern -- show -s localhost:7775 79d6c0218ddf8ab4869a69b5cc613ceb86d89ffc419637301e53b8ff950489f5/146
```
vs before.
```
plz run //discern -- show -s localhost:7775 --hash 79d6c0218ddf8ab4869a69b5cc613ceb86d89ffc419637301e53b8ff950489f5 --size 146
```