### PR TITLE
Cache GetTree calls

### DIFF
--- a/elan/main.go
+++ b/elan/main.go
@@ -16,10 +16,11 @@ var opts = struct {
 		FileVerbosity cli.Verbosity `long:"file_verbosity" default:"debug" description:"Verbosity of file logging output"`
 		LogFile       string        `long:"log_file" description:"File to additionally log output to"`
 	} `group:"Options controlling logging output"`
-	GRPC        grpcutil.Opts `group:"Options controlling the gRPC server"`
-	Storage     string        `short:"s" long:"storage" required:"true" description:"URL defining where to store data, eg. gs://bucket-name."`
-	Parallelism int           `long:"parallelism" default:"50" description:"Maximum number of in-flight parallel requests to the backend storage layer"`
-	Admin       admin.Opts    `group:"Options controlling HTTP admin server" namespace:"admin"`
+	GRPC         grpcutil.Opts `group:"Options controlling the gRPC server"`
+	Storage      string        `short:"s" long:"storage" required:"true" description:"URL defining where to store data, eg. gs://bucket-name."`
+	Parallelism  int           `long:"parallelism" default:"50" description:"Maximum number of in-flight parallel requests to the backend storage layer"`
+	DirCacheSize int64         `long:"dir_cache_size" default:"10240" description:"Number of directory entries to cache for GetTree"`
+	Admin        admin.Opts    `group:"Options controlling HTTP admin server" namespace:"admin"`
 }{
 	Usage: `
 Elan is an implementation of the content-addressable storage and action cache services
@@ -39,5 +40,5 @@ func main() {
 	opts.Admin.Logger = cli.MustGetLoggerNamed("github.com.thought-machine.http-admin")
 	opts.Admin.LogInfo = info
 	go admin.Serve(opts.Admin)
-	rpc.ServeForever(opts.GRPC, opts.Storage, opts.Parallelism)
+	rpc.ServeForever(opts.GRPC, opts.Storage, opts.Parallelism, opts.DirCacheSize)
 }

--- a/elan/rpc/BUILD
+++ b/elan/rpc/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//third_party/go:protobuf",
         "//third_party/go:remote-apis",
         "//third_party/go:remote-apis-sdks",
+        "//third_party/go:ristretto",
         "//third_party/go:rpcstatus",
         "//third_party/go/gocloud",
         "//third_party/go/gocloud:api",

--- a/elan/rpc/tree.go
+++ b/elan/rpc/tree.go
@@ -5,34 +5,41 @@ import (
 	"sync"
 
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	"github.com/hashicorp/go-multierror"
 )
-
-type dirResponse struct {
-	Dir *pb.Directory
-	Err error
-}
 
 // getTree returns a channel to iterate over all the directories recursively under the given one.
 // The responses are not necessarily returned in any particular order.
-func (s *server) getTree(digest *pb.Digest) chan *dirResponse {
-	var wg sync.WaitGroup
-	wg.Add(1)
-	ch := make(chan *dirResponse, 10)
-	go s.fetchDir(digest, &wg, ch)
-	go func() {
-		wg.Wait()
-		close(ch)
-	}()
-	return ch
-}
-
-func (s *server) fetchDir(digest *pb.Digest, wg *sync.WaitGroup, ch chan *dirResponse) {
+func (s *server) getTree(digest *pb.Digest) ([]*pb.Directory, error) {
 	dir := &pb.Directory{}
-	err := s.readBlobIntoMessage(context.Background(), "cas", digest, dir)
-	ch <- &dirResponse{Dir: dir, Err: err}
-	wg.Add(len(dir.Directories))
-	for _, child := range dir.Directories {
-		go s.fetchDir(child.Digest, wg, ch)
+	if digest.SizeBytes == 0 && digest.Hash == emptyHash {
+		return []*pb.Directory{dir}, nil
 	}
-	wg.Done()
+	if dir, present := s.dirCache.Get(digest.Hash); present {
+		d := dir.([]*pb.Directory)
+		dirCacheHits.Add(float64(len(d)))
+		return d, nil
+	}
+	dirCacheMisses.Inc()
+	if err := s.readBlobIntoMessage(context.Background(), "cas", digest, dir); err != nil {
+		return nil, err
+	}
+	ret := []*pb.Directory{dir}
+	var g multierror.Group
+	var mutex sync.Mutex
+	for _, child := range dir.Directories {
+		child := child
+		g.Go(func() error {
+			dirs, err := s.getTree(child.Digest)
+			mutex.Lock()
+			defer mutex.Unlock()
+			ret = append(ret, dirs...)
+			return err
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return ret, err
+	}
+	s.dirCache.Set(digest.Hash, ret, int64(len(ret)))
+	return ret, nil
 }


### PR DESCRIPTION
Some investigation suggests these are often common, and by their nature each subtree is the same, so we can remember the results. Got about a 90% hit rate even for a from-scratch build.

It caches every subtree; some of that is probably a little unnecessary since they're never addressed directly, but it's hard to know at this level which those are (and we can hope ristretto works that out and ditches them for us).