### PR TITLE
Better health check in Flair

### DIFF
--- a/elan/rpc/rclient.go
+++ b/elan/rpc/rclient.go
@@ -22,7 +22,7 @@ type remoteClient struct{
 func (r *remoteClient) Healthcheck() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10 * time.Second)
 	defer cancel()
-	if resp, err := r.health.Check(ctx, &hpb.HealthCheckRequest{Service: r.c.InstanceName}); err != nil {
+	if resp, err := r.health.Check(ctx, &hpb.HealthCheckRequest{}); err != nil {
 		return err
 	} else if resp.Status != hpb.HealthCheckResponse_SERVING {
 		return fmt.Errorf("Server not in healthy state: %s", resp.Status)

--- a/flair/trie/trie.go
+++ b/flair/trie/trie.go
@@ -179,6 +179,13 @@ func toInt(c byte) int {
 	}
 }
 
+func toHex(i int) byte {
+	if i >= 10 {
+		return byte('a' + i)
+	}
+	return byte('0' + i)
+}
+
 // Get returns a server from this trie.
 // It is assumed not to fail since the trie is already complete.
 func (t *Trie) Get(key string) *Server {
@@ -206,11 +213,7 @@ func (t *Trie) Check() error {
 
 func (t *Trie) check(prefix string, node *node) error {
 	for i, child := range node.children {
-		c := '0' + i
-		if i >= 10 {
-			c = 'a' + i
-		}
-		name := fmt.Sprintf("%s%c", prefix, c)
+		name := prefix + string(toHex(i))
 		if child.node != nil {
 			if err := t.check(name, child.node); err != nil {
 				return err

--- a/grpcutil/interceptors.go
+++ b/grpcutil/interceptors.go
@@ -127,6 +127,7 @@ var authenticatedMethods = map[string]bool{
 	"/google.bytestream.ByteStream/Read":                                          false,
 	"/google.bytestream.ByteStream/Write":                                         true,
 	"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo":              false,
+	"/grpc.health.v1.Health/Check":                                                false,
 }
 
 // authenticate authenticates an incoming RPC and returns an error if it's not permitted.

--- a/grpcutil/interceptors.go
+++ b/grpcutil/interceptors.go
@@ -31,6 +31,7 @@ type Opts struct {
 	CertFile  string `short:"c" long:"cert_file" description:"Cert file to load TLS credentials from"`
 	TokenFile string `long:"token_file" description:"File containing a pre-shared token that clients must provide as authentication."`
 	AuthAll   bool   `long:"auth_all" description:"Require authentication on all RPCs (by default only on RPCs that mutate state)"`
+	NoHealth  bool   `no-flag:"true" description:"Used internally to indicate when we don't want to automatically add a healthcheck."`
 }
 
 // NewServer creates a new gRPC server with a standard set of interceptors.
@@ -57,7 +58,9 @@ func NewServer(opts Opts) (net.Listener, *grpc.Server) {
 	)...)
 	grpc_prometheus.Register(s)
 	reflection.Register(s)
-	grpc_health_v1.RegisterHealthServer(s, health.NewServer())
+	if !opts.NoHealth {
+		grpc_health_v1.RegisterHealthServer(s, health.NewServer())
+	}
 	return lis, s
 }
 

--- a/mettle/worker/worker.go
+++ b/mettle/worker/worker.go
@@ -157,6 +157,7 @@ func runForever(instanceName, requestQueue, responseQueue, name, storage, dir, c
 	}()
 	for {
 		w.waitForFreeResources()
+		w.waitForLiveConnection()
 		w.waitIfDisabled()
 		w.Report(true, false, true, "Awaiting next task...")
 		if _, err := w.RunTask(ctx); err != nil {


### PR DESCRIPTION
This implements it by checking all the first-level ranges have at least one healthy server in them.