### PR TITLE
Mettle logs

### DIFF
--- a/mettle/api/api.go
+++ b/mettle/api/api.go
@@ -23,7 +23,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"gopkg.in/op/go-logging.v1"
 
 	"github.com/thought-machine/please-servers/grpcutil"
 	"github.com/thought-machine/please-servers/mettle/common"
@@ -365,7 +364,7 @@ func (s *server) process(msg *pubsub.Message) {
 		}
 	}
 	worker := common.WorkerName(msg)
-	if metadata.Stage == pb.ExecutionStage_COMPLETE {
+	if metadata.Stage == pb.ExecutionStage_COMPLETED {
 		if response := unmarshalResponse(op); response != nil && response.Status != nil && response.Status.Code != int32(codes.OK) {
 			log.Warning("Got an update for %s from %s, failed update: %s", metadata.ActionDigest.Hash, worker, response.Status.Message)
 		} else {

--- a/mettle/api/api.go
+++ b/mettle/api/api.go
@@ -367,12 +367,12 @@ func (s *server) process(msg *pubsub.Message) {
 	worker := common.WorkerName(msg)
 	if metadata.Stage == pb.ExecutionStage_COMPLETE {
 		if response := unmarshalResponse(op); response != nil && response.Status != nil && response.Status.Code != int32(codes.OK) {
-			log.Errorf("Worker %s got a failed update for %s: %s", worker, metadata.ActionDigest.Hash, response.Status.Message)
+			log.Warning("Got an update for %s from %s, failed update: %s", metadata.ActionDigest.Hash, worker, response.Status.Message)
 		} else {
 			log.Notice("Got an update for %s from %s, completed successfully", metadata.ActionDigest.Hash, worker)
 		}
 	} else {
-		log.Notice("Got an update for %s from %s, now %s message: %s", metadata.ActionDigest.Hash, worker, metadata.Stage)
+		log.Notice("Got an update for %s from %s, now %s", metadata.ActionDigest.Hash, worker, metadata.Stage)
 	}
 	s.mutex.Lock()
 	defer s.mutex.Unlock()


### PR DESCRIPTION
Adding logs to show whether an action has completed successfully or not which should make spotting miss-behaving workers a little simpler. 