### PR TITLE
Adding debug before metric increment

### DIFF
--- a/mettle/worker/worker.go
+++ b/mettle/worker/worker.go
@@ -497,6 +497,7 @@ func (w *worker) prepareDir(action *pb.Action, command *pb.Command) *rpcstatus.S
 	start := time.Now()
 	w.metadata.InputFetchStartTimestamp = toTimestamp(start)
 	if err := w.downloadDirectory(action.InputRootDigest); err != nil {
+		log.Notice("Error downloading directory. Code: %d", int(grpcstatus.Code(err)))
 		if grpcstatus.Code(err) == codes.NotFound {
 			log.Notice("Incrementing blobNotFoundErrors")
 			blobNotFoundErrors.Inc()

--- a/mettle/worker/worker.go
+++ b/mettle/worker/worker.go
@@ -498,6 +498,7 @@ func (w *worker) prepareDir(action *pb.Action, command *pb.Command) *rpcstatus.S
 	w.metadata.InputFetchStartTimestamp = toTimestamp(start)
 	if err := w.downloadDirectory(action.InputRootDigest); err != nil {
 		if grpcstatus.Code(err) == codes.NotFound {
+			log.Notice("Incrementing blobNotFoundErrors")
 			blobNotFoundErrors.Inc()
 		}
 		return inferStatus(codes.Unknown, "Failed to download input root: %s", err)


### PR DESCRIPTION
We're not seeing any increments to the blob_not_found_errors_total metric. I believe the code is correct, but it'd be useful to add some temporary debug to see if we're actually checking for the right thing before incrementing.