### PR TITLE
Add an explicit GC call in the worker before accepting a new task

### DIFF
--- a/mettle/worker/worker.go
+++ b/mettle/worker/worker.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -190,6 +191,9 @@ func runForever(instanceName, requestQueue, responseQueue, name, storage, dir, c
 		w.waitForFreeResources()
 		w.waitForLiveConnection()
 		w.waitIfDisabled()
+		// Run an explicit GC to clear up after the last task; ideally we leave as much free as
+		// possible for the subprocesses.
+		runtime.GC()
 		w.Report(true, false, true, "Awaiting next task...")
 		if _, err := w.RunTask(ctx); err != nil {
 			if ctx.Err() != nil {


### PR DESCRIPTION
Want to try to save memory for the subprocess; concerned that we might be using quite a bit if we had a heavy set of uploads (but have not yet reached the threshold to GC) and then the subprocess is gonna allocate a bunch more which won't trigger our GC either.