### PR TITLE
Fixing List() to take most recent LastAccessed time

### DIFF
--- a/flair/rpc/rpc.go
+++ b/flair/rpc/rpc.go
@@ -616,15 +616,20 @@ func (s *server) List(ctx context.Context, req *ppb.ListRequest) (*ppb.ListRespo
 				ar.Replicas = 1
 			}
 			if existing, present := ars[ar.Hash]; !present {
-				resp.ActionResults = append(resp.ActionResults, ar)
 				ars[ar.Hash] = ar
 			} else {
-				if existing.LastAccessed < ar.LastAccessed {
-					existing.LastAccessed = ar.LastAccessed
+				// Update ars with the replica, and use the more recent lastAccessed time.
+				ar.Replicas += existing.Replicas
+				if ar.LastAccessed < existing.LastAccessed {
+				    ar.LastAccessed = existing.LastAccessed
 				}
-				existing.Replicas += ar.Replicas
+				ars[ar.Hash] = ar
 			}
 		}
+		for _, ar := range(ars) {
+			resp.ActionResults = append(resp.ActionResults, ar)
+		}
+
 		for _, blob := range r.Blobs {
 			if strings.HasPrefix(blob.Hash, "tmp") {
 				continue

--- a/flair/rpc/rpc.go
+++ b/flair/rpc/rpc.go
@@ -621,12 +621,12 @@ func (s *server) List(ctx context.Context, req *ppb.ListRequest) (*ppb.ListRespo
 				// Update ars with the replica, and use the more recent lastAccessed time.
 				ar.Replicas += existing.Replicas
 				if ar.LastAccessed < existing.LastAccessed {
-				    ar.LastAccessed = existing.LastAccessed
+					ar.LastAccessed = existing.LastAccessed
 				}
 				ars[ar.Hash] = ar
 			}
 		}
-		for _, ar := range(ars) {
+		for _, ar := range ars {
 			resp.ActionResults = append(resp.ActionResults, ar)
 		}
 


### PR DESCRIPTION
Updating the List() function so that it uses the most recent LastAccessed time when there are two replicas of an action result.

I think this wasn’t working before because even though `existing.LastAccessed = ar.LastAccessed` is called to update the LastAccessed time, resp.ActionResults was never updated with this `existing` action result object.
