### PR TITLE
Adding debug

### DIFF
--- a/flair/rpc/rpc.go
+++ b/flair/rpc/rpc.go
@@ -619,6 +619,15 @@ func (s *server) List(ctx context.Context, req *ppb.ListRequest) (*ppb.ListRespo
 				resp.ActionResults = append(resp.ActionResults, ar)
 				ars[ar.Hash] = ar
 			} else {
+				// Temporary logging for debug purposes: if one replica is older than 72 hrs and one younger, make a note
+				minAge := 72 * time.Hour
+				ageThreshold := time.Now().Add(-minAge).Unix()
+				if (existing.LastAccessed < ageThreshold && ar.LastAccessed >= ageThreshold) || (ar.LastAccessed < ageThreshold && existing.LastAccessed >= ageThreshold) {
+					existingLastAccessed := time.Unix(existing.LastAccessed, 0)
+					arLastAccessed := time.Unix(ar.LastAccessed, 0)
+					log.Debug("AR %s: one replica accessed at %s, one at %s.", ar.Hash, existingLastAccessed, arLastAccessed)
+				}
+				// End temporary logging
 				if existing.LastAccessed < ar.LastAccessed {
 					existing.LastAccessed = ar.LastAccessed
 				}

--- a/purity/gc/gc.go
+++ b/purity/gc/gc.go
@@ -238,7 +238,7 @@ func (c *collector) MarkReferencedBlobs() error {
 				if c.shouldDelete(ar) {
 					accessed := time.Unix(ar.LastAccessed, 0)
 					threshold := time.Unix(c.ageThreshold, 0)
-					log.Notice("Should delete action result %s. LastAccessed is %s, ageThreshold is %s", ar.Hash, accessed, threshold)
+					log.Debug("Should delete action result %s. LastAccessed is %s, ageThreshold is %s", ar.Hash, accessed, threshold)
 				}
 				// End temporary logging
 				if !c.shouldDelete(ar) {

--- a/purity/gc/gc.go
+++ b/purity/gc/gc.go
@@ -234,6 +234,13 @@ func (c *collector) MarkReferencedBlobs() error {
 	for i := 0; i < (parallelism + 1); i++ {
 		go func(ars []*ppb.ActionResult) {
 			for _, ar := range ars {
+				// Temporary logging for debug purposes
+				if c.shouldDelete(ar) {
+					accessed := time.Unix(ar.LastAccessed, 0)
+					threshold := time.Unix(c.ageThreshold, 0)
+					log.Notice("Should delete action result %s. LastAccessed is %s, ageThreshold is %s", ar.Hash, accessed, threshold)
+				}
+				// End temporary logging
 				if !c.shouldDelete(ar) {
 					if err := c.markReferencedBlobs(ar); err != nil {
 						// Not fatal otherwise one bad action result will stop the whole show.


### PR DESCRIPTION
Temporary logs for debug:
 - Logging in rpc.go when we find one replica that's been accessed in the last 72 hours and one that hasn't. The action result shouldn't be deleted
 - Logging the lastAccessed time of all action results that are then scheduled for deletion in gc.go