### PR TITLE
Only delete job if it hasn't been overwritten

### DIFF
--- a/mettle/api/api.go
+++ b/mettle/api/api.go
@@ -443,19 +443,21 @@ func (s *server) process(msg *pubsub.Message) {
 		}
 		if op.Done {
 			log.Info("Job %s completed by %s", key, worker)
-			go s.deleteJob(key)
+			go s.deleteJob(key, j)
 			currentRequests.Dec()
 		}
 	}
 }
 
 // deleteJob waits for a period then removes the given job from memory.
-func (s *server) deleteJob(hash string) {
+func (s *server) deleteJob(hash string, j *job) {
 	time.Sleep(retentionTime)
 	log.Debug("Removing job %s", hash)
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	delete(s.jobs, hash)
+	if s.jobs[hash] == j {
+		delete(s.jobs, hash)
+	}
 }
 
 // expireJob expires an action that hasn't progressed.

--- a/mettle/api/api.go
+++ b/mettle/api/api.go
@@ -455,7 +455,7 @@ func (s *server) deleteJob(hash string, j *job) {
 	log.Debug("Removing job %s", hash)
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	// Check the action hasn't been replaced since deledJob was called
+	// Check the action hasn't been replaced since deleteJob was called
 	if s.jobs[hash] == j {
 		delete(s.jobs, hash)
 	}

--- a/mettle/api/api.go
+++ b/mettle/api/api.go
@@ -455,6 +455,7 @@ func (s *server) deleteJob(hash string, j *job) {
 	log.Debug("Removing job %s", hash)
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	// Check the action hasn't been replaced since deledJob was called
 	if s.jobs[hash] == j {
 		delete(s.jobs, hash)
 	}


### PR DESCRIPTION
If an action runs within 5 minutes of the same action completing the job gets deleted even though the entry in the map is replaced. This PR ensures a job is deleted only when the pointer to the job is the same as it was when deletejob is called