### PR TITLE
upgrading prometheus client

### DIFF
--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -224,12 +224,14 @@ go_module(
 
 go_module(
     name = "unix",
-    install = [
+     install = [
+        "cpu",
+        "execabs",
         "internal/unsafeheader",
         "unix",
     ],
     module = "golang.org/x/sys",
-    version = "ddb9806d33aed8dbaac1cd6f1cba58952e87f933",
+    version = "v0.0.0-20210423082822-04245dca01da",
 )
 
 go_module(
@@ -755,3 +757,83 @@ go_module(
     module = "go.uber.org/automaxprocs",
     version = "v1.4.0",
 )
+
+go_module(
+    name = "json-iterator",
+    install = ["..."],
+    licences = ["MIT"],
+    module = "github.com/json-iterator/go",
+    version = "v1.1.6",
+    deps = [
+        ":concurrent",
+        ":reflect2",
+    ],
+)
+
+go_module(
+    name = "concurrent",
+    install = ["..."],
+    licences = ["Apache-2.0"],
+    module = "github.com/modern-go/concurrent",
+    version = "1.0.3",
+)
+
+go_module(
+    name = "reflect2",
+    install = ["..."],
+    licences = ["Apache-2.0"],
+    module = "github.com/modern-go/reflect2",
+    version = "v1.0.1",
+    deps = [":concurrent"],
+)
+
+go_module(
+    name = "kingpin",
+    licences = ["MIT"],
+    module = "gopkg.in/alecthomas/kingpin.v2",
+    version = "v2.2.6",
+    deps = [
+        ":template",
+        ":units",
+    ],
+)
+
+go_module(
+    name = "template",
+    install = [
+        "",
+        "parse",
+    ],
+    licences = ["BSD-3-Clause"],
+    module = "github.com/alecthomas/template",
+    version = "a0175ee3bccc567396460bf5acd36800cb10c49c",
+)
+
+go_module(
+    name = "units",
+    licences = ["MIT"],
+    module = "github.com/alecthomas/units",
+    version = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a",
+)
+
+
+go_module(
+    name = "logrus",
+    licences = ["MIT"],
+    module = "github.com/sirupsen/logrus",
+    version = "v1.6.0",
+    deps = [
+        ":terminal",
+        ":unix",
+    ],
+)
+
+go_module(
+    name = "x_term",
+    install = ["..."],
+    licences = ["BSD-3-Clause"],
+    module = "golang.org/x/term",
+    version = "v0.0.0-20210615171337-6886f2dfbf5b",
+    deps = [":unix"],
+)
+

--- a/third_party/go/prometheus/BUILD
+++ b/third_party/go/prometheus/BUILD
@@ -2,19 +2,16 @@ package(default_visibility = ["PUBLIC"])
 
 go_module(
     name = "prometheus",
-    install = [
-        "prometheus",
-        "prometheus/internal",
-        "prometheus/promhttp",
-        "prometheus/push",
-    ],
+    install = ["..."],
     module = "github.com/prometheus/client_golang",
-    version = "v1.1.0",
+    version = "v1.11.0",
     deps = [
         ":client_model",
         ":perks",
         ":procfs",
         ":prometheus_common",
+        "//third_party/go:json-iterator",
+        "//third_party/go:xxhash_v2",
         "//third_party/go:net",
         "//third_party/go:protobuf",
     ],
@@ -27,7 +24,7 @@ go_module(
         "...",
     ],
     module = "github.com/grpc-ecosystem/go-grpc-prometheus",
-    version = "6af20e3a5340d5e6bde20c8a7a78699efe19ac0a",
+    version = "v1.2.0",
     deps = [
         ":prometheus",
         "//third_party/go:grpc",
@@ -59,7 +56,7 @@ go_module(
     name = "client_model",
     install = ["..."],
     module = "github.com/prometheus/client_model",
-    version = "14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016",
+    version = "v0.2.0",
     deps = [
         "//third_party/go:protobuf",
     ],
@@ -72,11 +69,13 @@ go_module(
         "model",
         "internal/...",
     ],
+    version = "v0.30.0",
     module = "github.com/prometheus/common",
-    version = "v0.7.0",
     deps = [
         ":client_model",
         ":golang_protobuf_extensions",
+        "//third_party/go:kingpin",
+        "//third_party/go:logrus",
         "//third_party/go:protobuf",
     ],
 )


### PR DESCRIPTION
We are seeing warning messages on successful pushes to the prom gateway. This issue was fixed in v1.2.0 of the Prometheus client.

This PR upgrades the prom client to 1.11.0. 

`16:23:44.498 WARNING: Error pushing to Prometheus pushgateway: unexpected status code 200 while pushing to...`