### PR TITLE
Update please to 16.19.0

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [please]
-version = >=16.0.1
+version = >=16.19.0
 
 [build]
 path = /usr/local/go/bin:/usr/local/bin:/usr/bin:/bin


### PR DESCRIPTION
A previous commit is failing the circleCI build with the below error. This is due to a bug in  a previous version of please.

Upgrading please to 16.19.0 solves this issue.

```
Downloading Please 16.0.1 to /root/.please/16.0.1...
Should be good to go now, running plz...
15:29:33.045  NOTICE: Build running for 10s, 350 / 687 tasks done, 29 workers busy
15:29:39.510   ERROR: //third_party/go:_template#a_rule failed:
error moving outputs for target //third_party/go:_template#a_rule: rule //third_party/go:_template#a_rule failed to create output plz-out/tmp/third_party/go/_template#a_rule._build/pkg/linux_amd64/github.com/alecthomas/template/.a
Build stopped after 19.73s. 1 target failed:
    //third_party/go:_template#a_rule
error moving outputs for target //third_party/go:_template#a_rule: rule //third_party/go:_template#a_rule failed to create output plz-out/tmp/third_party/go/_template#a_rule._build/pkg/linux_amd64/github.com/alecthomas/template/.a

Exited with code exit status 2
```
