### PR TITLE
Add temporary logging for missing output paths

### DIFF
--- a/mettle/worker/worker.go
+++ b/mettle/worker/worker.go
@@ -741,6 +741,7 @@ func containsAllOutputPaths(cmd *pb.Command, ar *pb.ActionResult) bool {
 	// Check that we generated all the required outputs
 	for _, p := range cmd.OutputPaths {
 		if !paths[p] {
+			log.Warningf("Action result doesn't contain output path %s. Action result object: %#v\n", p, ar)
 			return false
 		}
 	}


### PR DESCRIPTION
This will be useful as extra info to see why ARs aren't being cached properly.