### PR TITLE
Fix concurrent map writes in purity

### DIFF
--- a/purity/gc/gc.go
+++ b/purity/gc/gc.go
@@ -413,6 +413,8 @@ func (c *collector) markTree(d *pb.OutputDirectory) (int64, []*pb.Digest, error)
 }
 
 func (c *collector) markDirectory(d *pb.Directory) (int64, []*pb.Digest) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	var size int64
 	digests := []*pb.Digest{}
 	for _, f := range d.Files {


### PR DESCRIPTION
Purity clean is panicing due to concurrent map writes. This PR takes the collection of output digests out of markReferencedBlobs into it's own function so we can lock/unlock when necessary. 