### PR TITLE
Unshadow cancel func

### DIFF
--- a/mettle/common/common.go
+++ b/mettle/common/common.go
@@ -86,8 +86,8 @@ func handleSignals(cancel context.CancelFunc, s Shutdownable) {
 	signal.Notify(ch, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGABRT, syscall.SIGTERM)
 	go func() {
 		log.Warning("Received signal %s, shutting down queue", <-ch)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		ctx, cnx := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cnx()
 		if err := s.Shutdown(ctx); err != nil {
 			log.Error("Failed to shut down queue: %s", err)
 		}


### PR DESCRIPTION
The cancel function was shadowed in the common lib. We should look at how this propagates the cancel signal in practice now.