### PR TITLE
Don't ack until we have sent an update successfully

### DIFF
--- a/mettle/worker/worker.go
+++ b/mettle/worker/worker.go
@@ -425,10 +425,12 @@ func (w *worker) RunTask(ctx context.Context) (*pb.ExecuteResponse, error) {
 	w.downloadedBytes = 0
 	w.cachedBytes = 0
 	response := w.runTask(msg)
-	msg.Ack()
 	w.currentMsg = nil
 	err = w.update(pb.ExecutionStage_COMPLETED, response)
 	w.actionDigest = nil
+	if err == nil {
+		msg.Ack()
+	}
 	return response, err
 }
 


### PR DESCRIPTION
If something goes wrong, or we get shut down, this means we won't ack it until we are _completely_ done.