### PR TITLE
Always wrap prom registerer to avoid collector collisions

### DIFF
--- a/mettle/worker/worker.go
+++ b/mettle/worker/worker.go
@@ -127,13 +127,10 @@ var metrics = []prometheus.Collector{
 	collectOutputErrors,
 }
 
-func registerMetrics(name string, addName bool) {
-	r := prometheus.DefaultRegisterer
-	if addName {
-		r = prometheus.WrapRegistererWith(prometheus.Labels{
-			"worker": name,
-		}, r)
-	}
+func registerMetrics(name string) {
+	r := prometheus.WrapRegistererWith(prometheus.Labels{
+		"worker": name,
+	}, prometheus.DefaultRegisterer)
 	for _, metric := range metrics {
 		r.MustRegister(metric)
 	}
@@ -346,7 +343,7 @@ func initialiseWorker(instanceName, requestQueue, responseQueue, name, storage, 
 		w.lucidity = lpb.NewLucidityClient(conn)
 		go w.sendReports()
 	}
-	registerMetrics(name, promGatewayURL != "")
+	registerMetrics(name)
 	for name, cost := range costs {
 		w.costs[name] = &bbru.MonetaryResourceUsage_Expense{Currency: cost.Denomination, Cost: cost.Amount}
 	}


### PR DESCRIPTION
When running Mettle in `dual` mode and we don't specify a push gateway, prometheus would panic due to re-registering the metrics in the default registry. 

The metrics used to be set up in the `init` step, so the metrics would effectively be a singleton across the workers and this was never encountered.

