### PR TITLE
Handle execution timeouts as per the API spec

### DIFF
--- a/.plzconfig.localremote
+++ b/.plzconfig.localremote
@@ -1,0 +1,8 @@
+[Remote]
+URL = 127.0.0.1:7772
+CasUrl = 127.0.0.1:7777
+AssetUrl = 127.0.0.1:7776
+NumExecutors = 1
+TokenFile = grpcutil/token.txt
+Secure = false
+DisplayUrl = https://blah.com

--- a/mettle/worker/worker.go
+++ b/mettle/worker/worker.go
@@ -4,6 +4,7 @@ package worker
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -107,6 +108,9 @@ var collectOutputErrors = prometheus.NewCounter(prometheus.CounterOpts{
 	Namespace: "mettle",
 	Name:      "collect_output_errors_total",
 })
+
+// ErrTimeout is returned when the build action exceeds the action timeout
+var ErrTimeout = errors.New("action execution timed out")
 
 var metrics = []prometheus.Collector{
 	totalBuilds,
@@ -659,8 +663,15 @@ func (w *worker) execute(req *pb.ExecuteRequest, action *pb.Action, command *pb.
 		msg += w.writeUncachedResult(ar, msg)
 		// Attempt to collect outputs. They may exist and contain useful information such as a test.results file
 		_ = w.collectOutputs(ar, command)
+		// Still counts as OK on a status code.
+		status := &rpcstatus.Status{Code: int32(codes.OK)}
+		if err == ErrTimeout {
+			// For timeouts, the execution did not complete, so we should return this status as the docs suggest.
+			status.Code = int32(codes.DeadlineExceeded)
+			status.Message = ErrTimeout.Error()
+		}
 		return &pb.ExecuteResponse{
-			Status:  &rpcstatus.Status{Code: int32(codes.OK)}, // Still counts as OK on a status code.
+			Status:  status,
 			Result:  ar,
 			Message: msg,
 		}
@@ -793,14 +804,15 @@ func (w *worker) runCommand(cmd *exec.Cmd, timeout time.Duration) error {
 	case <-time.After(timeout):
 		log.Warning("Terminating process for %s due to timeout", w.actionDigest.Hash)
 		cmd.Process.Signal(os.Signal(syscall.SIGTERM))
-	}
-	select {
-	case err := <-ch:
-		return err
-	case <-time.After(5 * time.Second):
-		log.Warning("Killing process for %s", w.actionDigest.Hash)
-		cmd.Process.Kill()
-		return fmt.Errorf("Process timed out")
+
+		select {
+		case <-ch:
+			return ErrTimeout
+		case <-time.After(5 * time.Second):
+			log.Warning("Killing process for %s", w.actionDigest.Hash)
+			cmd.Process.Kill()
+			return ErrTimeout
+		}
 	}
 }
 

--- a/redis/redis.build
+++ b/redis/redis.build
@@ -14,7 +14,7 @@ c_library(
     name = "lua",
     srcs = glob(["deps/lua/src/*.c"], exclude = ["lua.c", "luac.c"]),
     hdrs = glob(["deps/lua/src/*.h", "src/solarisfixes.h"]),
-    cflags = ["-Wno-implicit-function-declaration"],  # They do slightly the wrong thing with strncasecmp
+    cflags = ["-Wno-implicit-function-declaration", "-Wmisleading-indentation"],  # They do slightly the wrong thing with strncasecmp
     includes = ["deps/lua/src"],
     defines = ["LUA_USE_MKSTEMP"],
 )


### PR DESCRIPTION
```
// If the status has a code other than `OK`, it indicates that the action did
// not finish execution. For example, if the operation times out during
// execution, the status will have a `DEADLINE_EXCEEDED` code. Servers MUST
// use this field for errors in execution, rather than the error field on the
// `Operation` object.
//
// If the status code is other than `OK`, then the result MUST NOT be cached.
// For an error status, the `result` field is optional; the server may
// populate the output-, stdout-, and stderr-related fields if it has any
// information available, such as the stdout and stderr of a timed-out action.
Status *status.Status `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
```

This implies we should return a non-ok status when the action execution times out. 