### PR TITLE
Reduce logging in purity, flair and elan

### DIFF
--- a/elan/rpc/rpc.go
+++ b/elan/rpc/rpc.go
@@ -298,7 +298,6 @@ func (s *server) FindMissingBlobs(ctx context.Context, req *pb.FindMissingBlobsR
 				mutex.Lock()
 				resp.MissingBlobDigests = append(resp.MissingBlobDigests, d)
 				mutex.Unlock()
-				log.Debug("Blob %s found to be missing", d.Hash)
 			}
 			wg.Done()
 		}(d)
@@ -370,7 +369,7 @@ func (s *server) BatchUpdateBlobs(ctx context.Context, req *pb.BatchUpdateBlobsR
 			} else if s.blobExists(ctx, s.compressedKey("cas", r.Digest, compressed)) {
 				log.Debug("Blob %s already exists remotely", r.Digest.Hash)
 			} else if err := s.writeAll(ctx, r.Digest, r.Data, compressed); err != nil {
-				log.Error("Error writing blob %s: %s", r.Digest, err)
+				log.Errorf("Error writing blob %s: %s", r.Digest, err)
 				rr.Status.Code = int32(status.Code(err))
 				rr.Status.Message = err.Error()
 				blobsReceived.WithLabelValues(batchLabel(true, false), compressorLabel(compressed)).Inc()

--- a/flair/trie/replication.go
+++ b/flair/trie/replication.go
@@ -75,7 +75,7 @@ func (r *Replicator) SequentialAck(key string, f ReplicatedAckFunc) error {
 			if !shouldContinue {
 				return nil // No need to do any more.
 			}
-			log.Debug("Caller requested to continue on next replica for %s", key)
+			log.Debugf("Caller requested to continue on next replica for %s", key)
 			success = true // we're always successful from here on
 			offset += r.increment
 			continue
@@ -84,9 +84,9 @@ func (r *Replicator) SequentialAck(key string, f ReplicatedAckFunc) error {
 		}
 		merr = multierror.Append(merr, err)
 		if i < r.Replicas-1 {
-			log.Debug("Error reading from replica for %s: %s. Will retry on next replica.", key, err)
+			log.Debugf("Error reading from replica for %s: %s. Will retry on next replica.", key, err)
 		} else {
-			log.Debug("Error reading from replica for %s: %s.", key, err)
+			log.Debugf("Error reading from replica for %s: %s.", key, err)
 		}
 		offset += r.increment
 	}

--- a/flair/trie/replication.go
+++ b/flair/trie/replication.go
@@ -84,9 +84,9 @@ func (r *Replicator) SequentialAck(key string, f ReplicatedAckFunc) error {
 		}
 		merr = multierror.Append(merr, err)
 		if i < r.Replicas-1 {
-			log.Error("Error reading from replica for %s: %s. Will retry on next replica.", key, err)
+			log.Debug("Error reading from replica for %s: %s. Will retry on next replica.", key, err)
 		} else {
-			log.Error("Error reading from replica for %s: %s.", key, err)
+			log.Debug("Error reading from replica for %s: %s.", key, err)
 		}
 		offset += r.increment
 	}
@@ -97,7 +97,7 @@ func (r *Replicator) SequentialAck(key string, f ReplicatedAckFunc) error {
 		// Don't log anything on a global NotFound; this is returned by GetActionResult to
 		// simply indicate the action result is not present, so it legitimately comes up often.
 		if code != codes.NotFound {
-			log.Warning("Reads from all replicas failed: %s", merr)
+			log.Warningf("Reads from all replicas failed: %s", merr)
 		}
 		return status.Errorf(code, "Reads from all replicas failed: %s", merr)
 	}
@@ -128,10 +128,9 @@ func (r *Replicator) Parallel(key string, f ReplicatedFunc) error {
 	}
 	if err := g.Wait(); err != nil {
 		if len(err.Errors) < r.Replicas {
-			log.Error("Writes to some replicas for %s failed: %s", key, err)
+			log.Errorf("Writes to some replicas for %s failed: %s", key, err)
 			return nil
 		}
-		log.Error("Writes to all replicas for %s failed: %s", key, err)
 		return err
 	}
 	return nil

--- a/purity/gc/gc.go
+++ b/purity/gc/gc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -277,7 +278,6 @@ func (c *collector) markReferencedBlobs(ar *ppb.ActionResult) error {
 	}
 	outputSize, digests, err := c.outputs(result)
 	if err != nil {
-		log.Warning("Couldn't download output tree for %s, continuing anyway: %s", ar.Hash, err)
 		return err
 	}
 	// Check whether all these outputs exist.
@@ -299,7 +299,11 @@ func (c *collector) markReferencedBlobs(ar *ppb.ActionResult) error {
 	c.inputSizes[ar.Hash] = int(inputSize)
 	c.outputSizes[ar.Hash] = int(outputSize)
 	if resp != nil && len(resp.MissingBlobDigests) > 0 {
-		return fmt.Errorf("Action result %s is missing %d digests", ar.Hash, len(resp.MissingBlobDigests))
+		digests := make([]string, len(resp.MissingBlobDigests))
+		for i, dg := range resp.MissingBlobDigests {
+			digests[i] = fmt.Sprintf("%s/%d", dg.Hash, dg.SizeBytes)
+		}
+		return fmt.Errorf("Action result is missing %d digests: %s", ar.Hash, len(resp.MissingBlobDigests), strings.Join(digests, ", "))
 	}
 	c.referencedBlobs[ar.Hash] = struct{}{}
 	return nil
@@ -345,7 +349,7 @@ func (c *collector) inputDirs(dg *pb.Digest) (int64, []*pb.Directory, *pb.Digest
 	var size int64
 	blob, present := c.allBlobs[dg.Hash]
 	if !present {
-		log.Debug("missing action for %s", dg.Hash)
+		log.Error("missing action for %s", dg.Hash)
 		atomic.AddInt64(&c.missingInputs, 1)
 		return size, nil, nil
 	}
@@ -353,20 +357,20 @@ func (c *collector) inputDirs(dg *pb.Digest) (int64, []*pb.Directory, *pb.Digest
 		Hash: dg.Hash,
 		Size: blob.SizeBytes,
 	}, action); err != nil {
-		log.Debug("Failed to read action %s: %s", dg.Hash, err)
+		log.Error("Failed to read action %s: %s", dg.Hash, err)
 		atomic.AddInt64(&c.missingInputs, 1)
 		return size, nil, nil
 	}
 	size += dg.SizeBytes
 	if action.InputRootDigest == nil {
-		log.Debug("nil input root for %s", dg.Hash)
+		log.Error("nil input root for %s", dg.Hash)
 		atomic.AddInt64(&c.missingInputs, 1)
 		return size, nil, nil
 	}
 	size += action.InputRootDigest.SizeBytes
 	dirs, err := c.client.GetDirectoryTree(ctx, action.InputRootDigest)
 	if err != nil {
-		log.Debug("Failed to read directory tree for %s (input root %s): %s", dg.Hash, action.InputRootDigest, err)
+		log.Error("Failed to read directory tree for %s (input root %s): %s", dg.Hash, action.InputRootDigest, err)
 		atomic.AddInt64(&c.missingInputs, 1)
 		return size, nil, action.InputRootDigest
 	}
@@ -756,7 +760,7 @@ func (c *collector) BlobUsage() ([]Blob, error) {
 		}
 		dir, present := m[digest.Hash]
 		if !present {
-			log.Debug("Failed to find input directory with hash %s", digest.Hash)
+			log.Error("Failed to find input directory with hash %s", digest.Hash)
 			return
 		}
 		for _, file := range dir.Files {

--- a/purity/gc/gc.go
+++ b/purity/gc/gc.go
@@ -349,7 +349,7 @@ func (c *collector) inputDirs(dg *pb.Digest) (int64, []*pb.Directory, *pb.Digest
 	var size int64
 	blob, present := c.allBlobs[dg.Hash]
 	if !present {
-		log.Error("missing action for %s", dg.Hash)
+		log.Errorf("missing action for %s", dg.Hash)
 		atomic.AddInt64(&c.missingInputs, 1)
 		return size, nil, nil
 	}
@@ -357,20 +357,20 @@ func (c *collector) inputDirs(dg *pb.Digest) (int64, []*pb.Directory, *pb.Digest
 		Hash: dg.Hash,
 		Size: blob.SizeBytes,
 	}, action); err != nil {
-		log.Error("Failed to read action %s: %s", dg.Hash, err)
+		log.Errorf("Failed to read action %s: %s", dg.Hash, err)
 		atomic.AddInt64(&c.missingInputs, 1)
 		return size, nil, nil
 	}
 	size += dg.SizeBytes
 	if action.InputRootDigest == nil {
-		log.Error("nil input root for %s", dg.Hash)
+		log.Errorf("nil input root for %s", dg.Hash)
 		atomic.AddInt64(&c.missingInputs, 1)
 		return size, nil, nil
 	}
 	size += action.InputRootDigest.SizeBytes
 	dirs, err := c.client.GetDirectoryTree(ctx, action.InputRootDigest)
 	if err != nil {
-		log.Error("Failed to read directory tree for %s (input root %s): %s", dg.Hash, action.InputRootDigest, err)
+		log.Errorf("Failed to read directory tree for %s (input root %s): %s", dg.Hash, action.InputRootDigest, err)
 		atomic.AddInt64(&c.missingInputs, 1)
 		return size, nil, action.InputRootDigest
 	}
@@ -760,7 +760,7 @@ func (c *collector) BlobUsage() ([]Blob, error) {
 		}
 		dir, present := m[digest.Hash]
 		if !present {
-			log.Error("Failed to find input directory with hash %s", digest.Hash)
+			log.Errorf("Failed to find input directory with hash %s", digest.Hash)
 			return
 		}
 		for _, file := range dir.Files {

--- a/purity/gc/gc.go
+++ b/purity/gc/gc.go
@@ -303,7 +303,7 @@ func (c *collector) markReferencedBlobs(ar *ppb.ActionResult) error {
 		for i, dg := range resp.MissingBlobDigests {
 			digests[i] = fmt.Sprintf("%s/%d", dg.Hash, dg.SizeBytes)
 		}
-		return fmt.Errorf("Action result is missing %d digests: %s", ar.Hash, len(resp.MissingBlobDigests), strings.Join(digests, ", "))
+		return fmt.Errorf("Action result is missing %d digests: %s", len(resp.MissingBlobDigests), strings.Join(digests, ", "))
 	}
 	c.referencedBlobs[ar.Hash] = struct{}{}
 	return nil


### PR DESCRIPTION
Our lofi setup is producing a lot of unnecessary log. This reduces that in preparation for turning debug logs on for elan to investigate write timeouts. 