### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.19'
+          go-version: '^1.20'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.48.0
+          version: v1.52.0
           args: cli/... discern/... elan/... flair/... grpcutil/... lucidity/... mettle/... purity/... rexclient/... zeal/...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: thoughtmachine/please-servers:20220816
+      image: thoughtmachine/please-servers:20230319
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,9 @@ issues:
     - appendAssign
     - halp  # Make misspell be quiet about this.
     - exitAfterDefer # Potentially useful but not in any cases it fires right now.
+    - unused-parameter # Quite a few of these, some legit, many are fulfilling interfaces
+    - redefines-builtin # Not really a big issue
+    - empty-block # Only came up once and was a false positive. This should be easily handled by review.
   exclude-rules:
     - path: _test\.go
       linters:
@@ -22,15 +25,12 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - asciicheck
     - bodyclose
     - dogsled

--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [please]
-version = >=16.22.0
+version = >=16.27.5
 
 [build]
 path = /usr/local/go/bin:/usr/local/bin:/usr/bin:/bin

--- a/.plzconfig
+++ b/.plzconfig
@@ -10,6 +10,7 @@ preloadsubincludes = ///go//build_defs:go
 [plugin "go"]
 target = //plugins:go
 importpath = github.com/thought-machine/please-servers
+gotool = //third_party/go:toolchain|go
 
 [python]
 moduledir = third_party/python

--- a/.plzconfig.ci
+++ b/.plzconfig.ci
@@ -5,6 +5,7 @@ dircompress = true
 
 [plugin "go"]
 defaultstatic = true
+gotool = //third_party/go:system_toolchain|go
 
 [proto]
 protoctool = protoc

--- a/browser/BUILD
+++ b/browser/BUILD
@@ -7,6 +7,7 @@ remote_file(
     hashes = [
         "f70c6e03abec5bc453d9adddc668d5da2c54f61e5d6c6da8d2816474e1cfd16e",
         "b01f200070805cf5180fc7aa1bc01b5bebdf516e176710fe8a54ee90a6db0084",
+        "8d9f4d6fc5c53c5461b4d8f8e8763156d26296d6a2eadd6ab7b58b5a53104918",
     ],
     url = "https://github.com/thought-machine/please-servers/releases/download/v9.2.1/bb_browser_${OS}_${ARCH}",
 )

--- a/mettle/common/common.go
+++ b/mettle/common/common.go
@@ -142,10 +142,7 @@ func CheckOutputPaths(cmd *pb.Command) error {
 	if err := checkOutputPaths(cmd.OutputFiles); err != nil {
 		return err
 	}
-	if err := checkOutputPaths(cmd.OutputPaths); err != nil {
-		return err
-	}
-	return nil
+	return checkOutputPaths(cmd.OutputPaths)
 }
 
 func checkOutputPaths(paths []string) error {

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,6 +1,6 @@
 plugin_repo(
     name = "go",
-    revision = "v0.4.4",
+    revision = "v1.2.1",
 )
 
 plugin_repo(

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,6 +1,7 @@
 plugin_repo(
     name = "go",
-    revision = "v1.2.1",
+    owner = 'peterebden',
+    revision = "ddf2638e75a4fd128568c919e251db75cc831e03",
 )
 
 plugin_repo(

--- a/redis/redis.build
+++ b/redis/redis.build
@@ -1,8 +1,8 @@
 subinclude("///cc//build_defs:c")
 
 package(cc = {
-    "default_opt_cflags": "--std=c99 -O3 -pipe -DNDEBUG -Wall -Werror -Wno-error=stringop-overflow -Wno-error=misleading-indentation",
-    "default_dbg_cflags": "--std=c99 -g3 -pipe -DDEBUG -Wall -Werror -Wno-error=stringop-overflow -Wno-error=misleading-indentation",
+    "default_opt_cflags": "--std=c99 -O3 -pipe -DNDEBUG -Wall -Wno-error=stringop-overflow -Wno-error=misleading-indentation",
+    "default_dbg_cflags": "--std=c99 -g3 -pipe -DDEBUG -Wall -Wno-error=stringop-overflow -Wno-error=misleading-indentation",
 })
 
 _release_h = """

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,3 @@
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 
-# gcc is needed until https://github.com/thought-machine/please/issues/797 is fixed
 RUN apk update && apk add musl-dev bash git curl libc6-compat python3 patch gcc linux-headers protoc tar

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -5,6 +5,10 @@ go_toolchain(
     version = "1.20.2",
 )
 
+go_system_toolchain(
+    name = "system_toolchain",
+)
+
 go_module(
     name = "logging",
     module = "gopkg.in/op/go-logging.v1",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -2,7 +2,7 @@ package(default_visibility = ["PUBLIC"])
 
 go_toolchain(
     name = "toolchain",
-    version = "1.19",
+    version = "1.20.2",
 )
 
 go_module(


### PR DESCRIPTION
 - Updates Go plugin & Go version, and actually uses toolchain (because we can't use the system Go 1.20)
 - Adds a `go_system_toolchain` for CI builds on Alpine.
 - Fix redis compile for presumably more recent gcc versions (I think we may as well turn off `-Werror` since we aren't writing this code ourselves)
 - Fix bb_browser for linux_arm64
 - Update `golangci-lint` to fix whatever was going wrong with it.