### PR TITLE
Allow selecting host for runlocal

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -4,6 +4,10 @@ version = >=17.0.0
 [build]
 path = /usr/local/go/bin:/usr/local/bin:/usr/bin:/bin
 
+[buildconfig]
+local-host = 127.0.0.1
+browser-url = http://127.0.0.1:7779
+
 [parse]
 preloadsubincludes = ///go//build_defs:go
 preloadsubincludes = ///shell//build_defs:shell

--- a/elan/BUILD
+++ b/elan/BUILD
@@ -13,5 +13,5 @@ go_binary(
 sh_cmd(
     name = "run_local",
     srcs = [":elan"],
-    cmd = "mkdir -p plz-out/elan && exec $(out_location :elan) --host 127.0.0.1 --port 7777 -s file://\\\\$PWD/plz-out/elan --log_file plz-out/log/elan.log --admin_host 127.0.0.1 --admin_port 9992 --token_file grpcutil/token.txt --known_blob_cache_size 20M",
+    cmd = f"mkdir -p plz-out/elan && exec $(out_location :elan) --host {CONFIG.LOCAL_HOST} --port 7777 -s file://\\\\$PWD/plz-out/elan --log_file plz-out/log/elan.log --admin_host 127.0.0.1 --admin_port 9992 --token_file grpcutil/token.txt --known_blob_cache_size 20M",
 )

--- a/flair/BUILD
+++ b/flair/BUILD
@@ -16,5 +16,5 @@ go_binary(
 sh_cmd(
     name = "run_local",
     srcs = [":flair"],
-    cmd = "exec $(out_location :flair) --host 127.0.0.1 --port 7772 -g 0-7:127.0.0.1:7777 -g 8-f:127.0.0.1:7777 -e 0-f:127.0.0.1:7778 -a 0-f:127.0.0.1:7776 --admin_disabled --token_file grpcutil/token.txt",
+    cmd = f"exec $(out_location :flair) --host {CONFIG.LOCAL_HOST} --port 7772 -g 0-7:127.0.0.1:7777 -g 8-f:127.0.0.1:7777 -e 0-f:127.0.0.1:7778 -a 0-f:127.0.0.1:7776 --admin_disabled --token_file grpcutil/token.txt",
 )

--- a/mettle/BUILD
+++ b/mettle/BUILD
@@ -15,10 +15,11 @@ go_binary(
 
 sh_cmd(
     name = "run_local",
-    cmd = "mkdir -p plz-out/mettle && exec $(out_location :mettle) dual --host 127.0.0.1 --port 7778 -s 127.0.0.1:7777 -s file://\\\\$PWD/plz-out/elan -s 127.0.0.1:7772 -d plz-out/mettle --log_file plz-out/log/mettle.log --browser http://127.0.0.1:7779 --sandbox $(out_location //sandbox:sandbox) --alt_sandbox $(out_location //sandbox:alt_sandbox) --admin_host 127.0.0.1 --token_file grpcutil/token.txt --redis_url 127.0.0.1:6379 --redis_password_file redis/auth --lucidity grpc://127.0.0.1:7774 --cache_dir plz-out/mettle-cache --cache_prefix third_party --memory_threshold 95.0 --version_file VERSION --cost cpu:£0.02 --cost mem:£0.01 --allowed_platform OSFamily:linux --allowed_platform OSFamily:macos --allowed_platform ISA:x86-64",
+    cmd = f"mkdir -p plz-out/mettle && exec $(out_location :mettle) dual --host {CONFIG.LOCAL_HOST} --port 7778 -s 127.0.0.1:7777 -s file://\\\\$PWD/plz-out/elan -s 127.0.0.1:7772 -d plz-out/mettle --log_file plz-out/log/mettle.log --browser {CONFIG.BROWSER_URL} --sandbox $(out_location //sandbox:sandbox) --alt_sandbox $(out_location //sandbox:alt_sandbox) --admin_host 127.0.0.1 --token_file grpcutil/token.txt --redis_url 127.0.0.1:6379 --redis_password_file redis/auth --lucidity grpc://127.0.0.1:7774 --cache_dir plz-out/mettle-cache --cache_prefix third_party --memory_threshold 95.0 --version_file VERSION --cost cpu:£0.02 --cost mem:£0.01 --allowed_platform OSFamily:linux --allowed_platform OSFamily:macos --allowed_platform ISA:x86-64",
     data = [
         ":mettle",
         "//sandbox",
         "//sandbox:alt_sandbox",
     ],
 )
+

--- a/zeal/BUILD
+++ b/zeal/BUILD
@@ -12,5 +12,5 @@ go_binary(
 sh_cmd(
     name = "run_local",
     srcs = [":zeal"],
-    cmd = "exec $(out_location :zeal) --host 127.0.0.1 --port 7776 -s 127.0.0.1:7777 -v 4 --log_file plz-out/log/zeal.log --admin_disabled --token_file grpcutil/token.txt",
+    cmd = f"exec $(out_location :zeal) --host {CONFIG.LOCAL_HOST} --port 7776 -s 127.0.0.1:7777 -v 4 --log_file plz-out/log/zeal.log --admin_disabled --token_file grpcutil/token.txt",
 )


### PR DESCRIPTION
This lets you do things like
```
plz -o buildconfig.local-host:0.0.0.0 -o buildconfig.browser-url:http://mymachine:7779 runlocal
```
to get something exposed to the local network (and with useful browser URLs for clients too)