### PR TITLE
Temporarily increase elan ctx timeouts

### DIFF
--- a/elan/rpc/client.go
+++ b/elan/rpc/client.go
@@ -20,7 +20,7 @@ func New(url string, tls bool, tokenFile string) (Client, error) {
 	if strings.Contains(url, "://") {
 		return &elanClient{
 			s:       createServer(url, 8, 10240, 10*1024*1024),
-			timeout: 1 * time.Minute,
+			timeout: 3 * time.Minute,
 		}, nil
 	}
 	client, err := rexclient.New("mettle", url, tls, tokenFile)

--- a/elan/rpc/eclient.go
+++ b/elan/rpc/eclient.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"time"
+	"fmt"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/uploadinfo"
@@ -28,7 +29,11 @@ func (e *elanClient) Healthcheck() error {
 func (e *elanClient) ReadBlob(dg *pb.Digest) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
 	defer cancel()
-	return e.s.readAllBlob(ctx, "cas", dg)
+	blob, err := e.s.readAllBlob(ctx, "cas", dg)
+	if err != nil {
+		return blob, fmt.Errorf("Error reading blob: %w", err)
+	}
+	return blob, nil
 }
 
 func (e *elanClient) WriteBlob(b []byte) (*pb.Digest, error) {
@@ -47,7 +52,11 @@ func (e *elanClient) WriteBlob(b []byte) (*pb.Digest, error) {
 	if e.s.blobExists(ctx, key) {
 		return dg, nil
 	}
-	return dg, e.s.bucket.WriteAll(ctx, key, b)
+	err := e.s.bucket.WriteAll(ctx, key, b)
+	if err != nil {
+		return dg, fmt.Errorf("Error writing blob: %w", err)
+	}
+	return dg, nil
 }
 
 func (e *elanClient) UpdateActionResult(req *pb.UpdateActionResultRequest) (*pb.ActionResult, error) {

--- a/elan/rpc/eclient.go
+++ b/elan/rpc/eclient.go
@@ -2,10 +2,10 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"time"
-	"fmt"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/uploadinfo"


### PR DESCRIPTION
This ctx timeout is hit fairly frequently when we deploy a new mettle, while the CAS is being repopulated. A long-term solution will be needed for any future migrations, but this increases the timeout for now so we don't have to ask people to rerun as many jobs. 

It also adds more info to errors reading & writing blobs; the 'context deadline exceeded' errors in particular can come from loads of places, so it'll be helpful to track where these have come from.