### PR TITLE
Refactor gauge strategy

### DIFF
--- a/mettle/api/api.go
+++ b/mettle/api/api.go
@@ -173,6 +173,8 @@ func serve(opts grpcutil.Opts, name string, queueOpts PubSubOpts, apiURL string,
 			Name:      "requests_current",
 		},
 			func() float64 {
+				srv.mutex.Lock()
+				defer srv.mutex.Unlock()
 				return float64(len(srv.jobs))
 			},
 		))


### PR DESCRIPTION
Given that the job requests are quite a hot function, and we care only about snapshots of the requests, this refactors it to use a GuageFunc to get the length of the jobs map when it's scraped. 

The registering code needs to close over the `server`, which is the only slighy ugliness of this approach, especially needing to wrap with `sync.Once` otherwise the tests panic.