### PR TITLE
WIP: Teach Purity about instance names 

### DIFF
--- a/proto/purity/purity.proto
+++ b/proto/purity/purity.proto
@@ -16,6 +16,8 @@ service GC {
 message ListRequest {
   // The prefix of blobs to list. Should be exactly two hex characters.
   string prefix = 1;
+  // The instance name for the CAS server.
+  string instance_name = 2;
 }
 
 message ListResponse {
@@ -53,6 +55,8 @@ message DeleteRequest {
   // False gives the server an option to 'soft' delete them (however it may
   // interpret that).
   bool hard = 4;
+  // The instance name for the CAS server.
+  string instance_name = 5;
 }
 
 message DeleteResponse {}

--- a/purity/main.go
+++ b/purity/main.go
@@ -20,7 +20,7 @@ var opts = struct {
 	Logging cli.LoggingOpts `group:"Options controlling logging output"`
 	GC      struct {
 		URL          string `short:"u" long:"url" required:"true" description:"URL for the storage server"`
-		InstanceName string `short:"i" long:"instance_name" default:"purity-gc" description:"Name of this execution instance"`
+		InstanceName string `short:"i" long:"instance_name" default:"mettle" description:"Name of this execution instance"`
 		TokenFile    string `long:"token_file" description:"File containing token to authenticate gRPC requests with"`
 		TLS          bool   `long:"tls" description:"Use TLS for communicating with the storage server"`
 	} `group:"Options controlling GC settings"`


### PR DESCRIPTION
Purity abuses the instance name for the REX Api to make Elan have special cases. Additionally, it doesn't pass through instance names through out.

Still need to re-generate the protos, and ran into some "fun".