### PR TITLE
Minor discern enhancements

### DIFF
--- a/discern/main.go
+++ b/discern/main.go
@@ -36,7 +36,7 @@ var opts = struct {
 	} `command:"diff" description:"Show differences between two actions"`
 	Show struct {
 		NoInputs bool `long:"no_inputs" description:"Don't list input files"`
-		Args struct {
+		Args     struct {
 			Actions []cli.Action `positional-arg-name:"action" required:"true" description:"Hashes of actions to display"`
 		} `positional-args:"true"`
 	} `command:"show" description:"Show detail about an action or series of them"`


### PR DESCRIPTION
Allow skipping reading all the inputs, which can be very slow when the tree is large.
Also print stdout and stderr of action results.