### PR TITLE
Update Go version to 1.23.2

### DIFF
--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -4,7 +4,7 @@ package(default_visibility = ["PUBLIC"])
 
 go_toolchain(
     name = "toolchain",
-    version = "1.22.5",
+    version = "1.23.2",
     install_std = False,
 )
 


### PR DESCRIPTION
Looks like we don't have anything referring to it in the GHA config so that doesn't need to change \o/